### PR TITLE
Enabling BLASterDeepLLL for reduction with bkz parameters in dimension < 40

### DIFF
--- a/src/blaster.py
+++ b/src/blaster.py
@@ -225,6 +225,8 @@ def reduce(
     try:
         if not beta:
             lll_reduce(B, U, U_seysen, lll_size, delta, depth, tprof, tracers, debug, use_seysen)
+        elif beta < 40:
+            lll_reduce(B, U, U_seysen, lll_size, delta, 4, tprof, tracers, debug, use_seysen)  # depth is 4 
         else:
             # Parse BKZ parameters:
             bkz_tours = kwds.get("bkz_tours") or 1


### PR DESCRIPTION
Calling "reduce" in https://github.com/ludopulles/BLASter/blob/main/src/blaster.py with BKZ parameters for lattices of dimension < 40 does not perform any lattice reduction due to the choice of range in Line 237. 

As discussed by E-mail and thanks to ludopulles, the suggested change fixes this behavior to call BLASterDeepLLL with depth 4 on lattices of dimension < 40, as suggested in Algorithm 5 of the accompanying paper https://eprint.iacr.org/2025/774.pdf .
